### PR TITLE
Use mdBook 0.3.5 and download binary instead of compiling it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
-language: rust
+language: minimal
 sudo: false
-
-cache:
-  - cargo
-
-rust:
-  - stable
 
 before_script:
   # Retrieve and install latest mdbook version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: generic
+language: rust
 sudo: false
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,12 @@ rust:
   - stable
 
 before_script:
-  - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-  - (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.2.1" mdbook)
-  - cargo install-update -a
+  # Retrieve and install latest mdbook version
+  - export MDBOOK_VERSION='0.3.1' # Change to use newer version
+  - mkdir $HOME/.mdbook
+  - curl -L -o mdbook.tar.gz https://github.com/rust-lang-nursery/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz && tar -C $HOME/.mdbook -xzvf mdbook.tar.gz
+  - rm mdbook.tar.gz
+  - export PATH=$HOME/.mdbook/mdbook:$PATH
 
 script:
   - mdbook build && mdbook test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
   - mkdir $HOME/.mdbook
   - curl -L -o mdbook.tar.gz https://github.com/rust-lang-nursery/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz && tar -C $HOME/.mdbook -xzvf mdbook.tar.gz
   - rm mdbook.tar.gz
-  - export PATH=$HOME/.mdbook/mdbook:$PATH
+  - export PATH=$HOME/.mdbook:$PATH
 
 script:
   - mdbook build && mdbook test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ sudo: false
 
 before_script:
   # Retrieve and install latest mdbook version
-  - export MDBOOK_VERSION='0.3.1' # Change to use newer version
-  - mkdir $HOME/.mdbook
-  - curl -L -o mdbook.tar.gz https://github.com/rust-lang-nursery/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz && tar -C $HOME/.mdbook -xzvf mdbook.tar.gz
-  - rm mdbook.tar.gz
+  - misc/download-mdbook.sh 0.3.5
   - export PATH=$HOME/.mdbook:$PATH
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: minimal
+language: generic
 sudo: false
 
 before_script:

--- a/misc/download-mdbook.sh
+++ b/misc/download-mdbook.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+MDBOOK_VERSION=${1:-0.3.5}
+
+install_mdbook=false
+
+if [[ -x $HOME/.cargo/bin/mdbook ]]; then
+    echo "Checking for mdBook version ${MDBOOK_VERSION}"
+    EXISTING_MDBOOK_VERSION=`$HOME/.cargo/bin/mdbook --version`
+    echo "Existing: ${EXISTING_MDBOOK_VERSION}"
+    if [ "mdbook v${MDBOOK_VERSION}" != "${EXISTING_MDBOOK_VERSION}" ]; then
+        install_mdbook=true
+    else
+        echo "Using cached ${EXISTING_MDBOOK_VERSION}"
+        install_mdbook=false
+    fi
+else
+     install_mdbook=true
+fi
+
+if [ "$install_mdbook" = true ] ; then
+        echo "Installing mdBook version ${MDBOOK_VERSION}"
+
+        if [[ "$TRAVIS_OS_NAME" == "linux" ]];
+        then
+            rm -f mdbook.tar.gz
+            curl -L -o mdbook.tar.gz https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz
+            tar -C $HOME/.cargo/bin/ -zxf mdbook.tar.gz
+        elif [[ "$TRAVIS_OS_NAME" == "osx" ]];
+        then
+            rm -f mdbook.tar.gz
+            curl -L -o mdbook.tar.gz https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-apple-darwin.tar.gz
+            tar -C $HOME/.cargo/bin/ -zxf mdbook.tar.gz
+        elif [[ "$TRAVIS_OS_NAME" == "windows" ]];
+        then
+            del /s /q mdbook.tar.gz
+            curl -L -o mdbook.zip https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdBook-v${MDBOOK_VERSION}-x86_64-pc-windows-msvc.zip
+            unzip -o -d $HOME/.cargo/bin/ mdbook.zip
+        else
+            >&2 echo "Unknown value \"${TRAVIS_OS_NAME}\" for environment variable TRAVIS_OS_NAME"
+        	exit 1
+        fi
+fi
+


### PR DESCRIPTION
Currently, executing a pull request check with Travis takes about 1 1/2 minutes. This is quite long for getting instant feedback or deploying changes. In the worst case without a working cache, executing the CI job can take almost half an hour.

Even if the compiled mdBook binary is cached by Travis, restoring the cache takes about 14 seconds because of the size of all Rust dependencies. Storing the cached data and uploading it takes time, too.
In comparison, downloading and unpacking the compiled binary should be much faster (less than 2 seconds).
Updating to mdBook 0.3.1 also brings some bug fixes and its the version I use for local tests.