### PR TITLE
Activate link to user & dev docs

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -24,5 +24,5 @@ The project is located at the
 
 [![Logo of Humboldt-Universität zu Berlin](hu.png)](https://www.hu-berlin.de/en?set_language=en)
 
-> The **Hexatomic software documentation** will be hosted at  
-<i class="fa fa-floppy-o"></i> **https://hexatomic.github.io/hexatomic**.
+> The **Hexatomic software documentation** is hosted at  
+<i class="fa fa-floppy-o"></i> [**hexatomic.github.io/hexatomic**](https://hexatomic.github.io/hexatomic).


### PR DESCRIPTION
Now that the docs are online, the link on the project index page should be active.