### PR TITLE
Add download button with link to latest release to nav

### DIFF
--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -93,6 +93,7 @@
                 </li>
             </ol>
             <hr>
+            <p><a href="https://github.com/hexatomic/hexatomic/releases/latest"><button style="background-color: #4183c4; border: none; color: white; padding: 12px 30px; cursor: pointer; width: 100%"><i class="fa fa-download"></i> Download Hexatomic</button></a></p>
             <p><i class="fa fa-copyright"></i> 2018ff. <a href="https://github.com/orgs/hexatomic/teams/project/members" target="_blank">Hexatomic project team</a></p>
             <p><i class="fa fa-envelope"></i> hexatomic [at] corpus-tools.org</p>
             <p><i class="fa fa-github"></i> <a href="https://github.com/hexatomic" target="_blank">github.com/hexatomic</a></p>


### PR DESCRIPTION
This PR adds a download button to the nav bar which links to https://github.com/hexatomic/hexatomic/releases/latest.

![image](https://user-images.githubusercontent.com/3007126/70861440-3bc5d900-1f2e-11ea-935e-3e41898b3214.png)
