### PR TITLE
Fix warnings in Travis config, update to deploy v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: rust
-sudo: false
 
 before_script:
   # Retrieve and install latest mdbook version
@@ -11,7 +10,7 @@ script:
 
 deploy:
   provider: pages
-  skip-cleanup: true
+  cleanup: false
   github-token: $GITHUB_TOKEN
   local-dir: book
   keep-history: true


### PR DESCRIPTION
This PR fixes the Travis config, as  `sudo` is deprecated (The key `sudo` has no effect anymore.), and `skip_cleanup` is also deprecated (not supported in dpl v2, use `cleanup`).